### PR TITLE
Clean up time zone handling in pull_data.sql

### DIFF
--- a/etc/pull_data.sql
+++ b/etc/pull_data.sql
@@ -110,10 +110,9 @@ COPY (
 COPY (
 	SELECT 
 		t.trip_id,
-		-- time formatting nightmare
 		-- TODO note the timezones in the time calculations
-		(to_timestamp(round(etime)) at time zone :local_tz)::time AS arrival_time,
-		(to_timestamp(round(etime)) at time zone :local_tz)::time AS departure_time,
+		(to_timestamp(round(etime)) at time zone :'local_tz')::time AS arrival_time,
+		(to_timestamp(round(etime)) at time zone :'local_tz')::time AS departure_time,
 		stop_sequence,
 		fake_stop_id AS stop_id
 	FROM :stop_times_table AS st JOIN :trips_table AS t ON st.trip_id = t.trip_id

--- a/etc/pull_data.sql
+++ b/etc/pull_data.sql
@@ -15,7 +15,7 @@
 \set trips_table       jv_trips
 \set stop_times_table  jv_stop_times
 -- timezone offset
-\set tzoffset          -4
+\set local_tz          'America/Toronto'
 -- where to save the output
 \set outdir            '/home/nate/retro-gtfs/output/jv/'
 -- stop configuration past here... just setting output locations from 
@@ -112,16 +112,8 @@ COPY (
 		t.trip_id,
 		-- time formatting nightmare
 		-- TODO note the timezones in the time calculations
-		(
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int / 3600, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 3600 / 60, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 60, 'fm00' )
-		) AS arrival_time,
-		(
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int / 3600, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 3600 / 60, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 60, 'fm00' )
-		) AS departure_time,
+		(to_timestamp(round(etime)) at time zone :local_tz)::time AS arrival_time,
+		(to_timestamp(round(etime)) at time zone :local_tz)::time AS departure_time,
 		stop_sequence,
 		fake_stop_id AS stop_id
 	FROM :stop_times_table AS st JOIN :trips_table AS t ON st.trip_id = t.trip_id


### PR DESCRIPTION
Currently, the time zone conversions in `pull_data.sql` rely on some pretty hairy string formatting and use an integer time zone offset, which will not for example correct for Daylight Savings Time.

To clean this up and allow for more robust (e.g. DST) handling, I changed the tz offset to a [tz database time zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) and took advantage of the built-in time zone functions on postgres.