### PR TITLE
Update transit profile to work with latest osrm-backend

### DIFF
--- a/etc/pull_data.sql
+++ b/etc/pull_data.sql
@@ -15,7 +15,7 @@
 \set trips_table       jv_trips
 \set stop_times_table  jv_stop_times
 -- timezone offset
-\set tzoffset          -4
+\set local_tz          'America/Toronto'
 -- where to save the output
 \set outdir            '/home/nate/retro-gtfs/output/jv/'
 -- stop configuration past here... just setting output locations from 
@@ -112,16 +112,8 @@ COPY (
 		t.trip_id,
 		-- time formatting nightmare
 		-- TODO note the timezones in the time calculations
-		(
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int / 3600, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 3600 / 60, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 60, 'fm00' )
-		) AS arrival_time,
-		(
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int / 3600, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 3600 / 60, 'fm00' ) ||':'||
-			to_char( (etime+:tzoffset*3600-service_id*86400)::int % 60, 'fm00' )
-		) AS departure_time,
+		(to_timestamp(round(etime)) at time zone :local_tz)::time AS arrival_time,
+		(to_timestamp(round(etime)) at time zone :local_tz)::time AS departure_time,
 		stop_sequence,
 		fake_stop_id AS stop_id
 	FROM :stop_times_table AS st JOIN :trips_table AS t ON st.trip_id = t.trip_id

--- a/etc/ttc.lua
+++ b/etc/ttc.lua
@@ -83,6 +83,11 @@ function setup()
       'destination'
     },
 
+    -- tags disallow access to in combination with highway=service
+    service_access_tag_blacklist = Set {
+        'private'
+    },
+
     restricted_access_tag_list = Set {
       'private',
       'delivery',
@@ -116,7 +121,7 @@ function setup()
     },
 
     classes = Sequence {
-        'toll', 'motorway', 'ferry', 'restricted'
+        'toll', 'motorway', 'ferry', 'restricted', 'tunnel'
     },
 
     -- classes to support for exclude flags


### PR DESCRIPTION
When running `osrm-extract -p /path/to/ttc.lua /path/to/osmextract.osm.pbf`, I ran into two subsequent errors (one after fixing the other).

First:
```
libc++abi.dylib: terminating with uncaught exception of type tbb::captured_exception: lua: error: ...etro_gtfs_all/osrm-backend/profiles/lib/way_handlers.lua:87: attempt to index a nil value (field 'service_access_tag_blacklist')
Abort trap: 6
```

Then:
```
libc++abi.dylib: terminating with uncaught exception of type osrm::util::exception: Profile used unknown class name: tunnel
Abort trap: 6
```

I went into the latest versions of the osrm-backend default profiles (`car.lua`, `foot.lua`, etc.) to see if I could find the discrepancies; this turned out to be pretty straightforward. I then just copy/pasted the `service_access_tag_blacklist` set definition, and added `tunnel` to the `Classes` sequence, in the custom transit profile. These fixed the problems and I was able to run everything smoothly.